### PR TITLE
[SP-13257] Add cron schedule to E2E Tests workflow so that the job runs at 2 AM every day.

### DIFF
--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -5,6 +5,8 @@ on:
       - main
     paths:
       - swov1/**
+    schedule:
+      - cron: '0 2 * * *'  # Run at 2 AM UTC every day
   workflow_dispatch:
 jobs:
   e2e-tests:


### PR DESCRIPTION
JIRA Ticket: https://swicloud.atlassian.net/browse/SP-13257

Added cron schedule to E2E Tests workflow so that the job runs at 2 AM every day.