### PR TITLE
ci: bump E2E container to golang:1.25-alpine

### DIFF
--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -12,7 +12,7 @@ jobs:
   e2e-tests:
     runs-on: ubuntu-latest
     container:
-      image: golang:1.23-alpine
+      image: golang:1.25-alpine
     env:
       SWO_STAGE_API_TOKEN: ${{ secrets.SWO_API_TOKEN }}
       PUBLIC_SWO_API_STAGE_URL: ${{ secrets.PUBLIC_SWO_API_STAGE_URL }}


### PR DESCRIPTION
The Speakeasy-generated `go.mod` now sets the Go directive to 1.25.10, but the E2E Tests job runs in a `golang:1.23-alpine` container. The Compile SDK step fails during generation with:

```
go: go.mod requires go >= 1.25.10 (running go 1.23.12; GOTOOLCHAIN=local)
```

This fails before any test runs and blocks every SDK regeneration PR. Bumping the container to `golang:1.25-alpine` satisfies the directive.